### PR TITLE
Make GridColumnElement a fake element

### DIFF
--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridColumnElement.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridColumnElement.java
@@ -20,10 +20,28 @@ import com.vaadin.testbench.elementsbase.Element;
 
 /**
  * A TestBench element representing a <code>&lt;vaadin-grid-column&gt;</code>
- * element.
+ * element. This is not a TestBenchElement as polyfilled browsers are not
+ * capable of finding it or handling it as a web element.
  */
 @Element("vaadin-grid-column")
-public class GridColumnElement extends TestBenchElement {
+public class GridColumnElement {
+
+    private GridElement grid;
+    private Long __generatedId;
+
+    public GridColumnElement(Long __generatedId, GridElement grid) {
+        this.grid = grid;
+        this.__generatedId = __generatedId;
+    }
+
+    /**
+     * For internal use only.
+     *
+     * @return the generated id for the column
+     */
+    protected Long get__generatedId() {
+        return __generatedId;
+    }
 
     /**
      * Gets the header cell for this column.
@@ -33,7 +51,16 @@ public class GridColumnElement extends TestBenchElement {
      * @return the header cell for the column
      */
     public GridTHTDElement getHeaderCell() {
-        return getPropertyElement("_headerCell").wrap(GridTHTDElement.class);
+        return ((TestBenchElement) execJs("return column._headerCell"))
+                .wrap(GridTHTDElement.class);
+    }
+
+    private Object execJs(String js) {
+        return grid.getCommandExecutor()
+                .executeScript("var grid = arguments[0];" //
+                        + "var generatedId = arguments[1];"
+                        + "var column = grid._getColumns().filter(function(column) {return column.__generatedTbId == generatedId;})[0];"
+                        + js, grid, __generatedId);
     }
 
     /**
@@ -44,6 +71,18 @@ public class GridColumnElement extends TestBenchElement {
      * @return the footer cell for the column
      */
     public GridTHTDElement getFooterCell() {
-        return getPropertyElement("_footerCell").wrap(GridTHTDElement.class);
+        return ((TestBenchElement) execJs("return column._footerCell"))
+                .wrap(GridTHTDElement.class);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof GridColumnElement)) {
+            return false;
+        }
+
+        return get__generatedId()
+                .equals(((GridColumnElement) obj).get__generatedId());
+    }
+
 }

--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTHTDElement.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.component.grid.testbench;
 
 import java.util.List;
 
+import org.openqa.selenium.NoSuchElementException;
+
 import com.vaadin.testbench.TestBenchElement;
 
 /**
@@ -27,8 +29,11 @@ public class GridTHTDElement extends TestBenchElement {
 
     @Override
     public String getText() {
-        TestBenchElement slot = getPropertyElement("firstElementChild");
-        return getSlotText(slot);
+        return (String) executeScript("var cell = arguments[0];"
+                + "return Array.from(cell.firstElementChild.assignedNodes()).map(function(node) { return node.textContent;}).join('');",
+                this);
+        // TestBenchElement slot = getPropertyElement("firstElementChild");
+        // return getSlotText(slot);
     }
 
     /**
@@ -63,6 +68,27 @@ public class GridTHTDElement extends TestBenchElement {
      * @return the column element
      */
     public GridColumnElement getColumn() {
-        return getPropertyElement("_column").wrap(GridColumnElement.class);
+        Double id = getPropertyDouble("_column", "__generatedTbId");
+        GridElement grid = getGrid();
+        if (id == null) {
+            grid.generatedColumnIdsIfNeeded();
+            id = getPropertyDouble("_column", "__generatedTbId");
+        }
+        if (id == null) {
+            throw new NoSuchElementException(
+                    "Unable to find column. This should not really happen.");
+        }
+        return new GridColumnElement(id.longValue(), grid);
+    }
+
+    /**
+     * Gets the grid containing this element.
+     *
+     * @return the grid for this element
+     */
+    public GridElement getGrid() {
+        return ((TestBenchElement) executeScript(
+                "return arguments[0].getRootNode().host", this))
+                        .wrap(GridElement.class);
     }
 }

--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTRElement.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/grid/testbench/GridTRElement.java
@@ -32,10 +32,10 @@ public class GridTRElement extends TestBenchElement {
     public GridTHTDElement getCell(GridColumnElement column) {
         TestBenchElement e = (TestBenchElement) executeScript(
                 "const grid = arguments[0];" //
-                        + "const column = arguments[1];" //
+                        + "const columnId = arguments[1];" //
                         + "return Array.from(grid.children)."
-                        + "filter(function(cell) { return cell._column == column;})[0]",
-                this, column);
+                        + "filter(function(cell) { return cell._column.__generatedTbId == columnId;})[0]",
+                this, column.get__generatedId());
         return e.wrap(GridTHTDElement.class);
     }
 


### PR DESCRIPTION
Firefox, IE and Edge refuse to refer to elements only availabl in the light
DOM. Probable reason is that the elements are not in the actual DOM and
one or another check in the webdrivers conclude that the elements have been
detached. Using such elements always results in a StaleElementReferenceException.