### PR TITLE
Test also text inputs in eager mode

### DIFF
--- a/vaadin-components-testbench-test/src/main/java/com/vaadin/flow/component/textfield/testbench/test/PasswordFieldView.java
+++ b/vaadin-components-testbench-test/src/main/java/com/vaadin/flow/component/textfield/testbench/test/PasswordFieldView.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield.testbench.test;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.component.common.testbench.test.AbstractView;
 import com.vaadin.flow.component.textfield.PasswordField;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;
@@ -26,7 +27,7 @@ import com.vaadin.flow.theme.lumo.Lumo;
 @Theme(Lumo.class)
 public class PasswordFieldView extends AbstractView {
 
-    public static final String LABEL = "text";
+    public static final String LABEL_EAGER = "text";
     public static final String NOLABEL = "notext";
     public static final String INITIAL_VALUE = "initialvalue";
     public static final String PLACEHOLDER = "placeholder";
@@ -38,8 +39,9 @@ public class PasswordFieldView extends AbstractView {
         passwordFieldNoLabel.addValueChangeListener(this::onValueChange);
         add(passwordFieldNoLabel);
 
-        PasswordField passwordFieldLabel = new PasswordField("Label");
-        passwordFieldLabel.setId(LABEL);
+        PasswordField passwordFieldLabel = new PasswordField("Label (eager)");
+        passwordFieldLabel.setValueChangeMode(ValueChangeMode.EAGER);
+        passwordFieldLabel.setId(LABEL_EAGER);
         passwordFieldLabel.addValueChangeListener(this::onValueChange);
         add(passwordFieldLabel);
 

--- a/vaadin-components-testbench-test/src/main/java/com/vaadin/flow/component/textfield/testbench/test/TextAreaView.java
+++ b/vaadin-components-testbench-test/src/main/java/com/vaadin/flow/component/textfield/testbench/test/TextAreaView.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield.testbench.test;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.component.common.testbench.test.AbstractView;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;
@@ -26,7 +27,7 @@ import com.vaadin.flow.theme.lumo.Lumo;
 @Theme(Lumo.class)
 public class TextAreaView extends AbstractView {
 
-    public static final String LABEL = "text";
+    public static final String LABEL_EAGER = "text";
     public static final String NOLABEL = "notext";
     public static final String INITIAL_VALUE = "initialvalue";
     public static final String PLACEHOLDER = "placeholder";
@@ -38,8 +39,9 @@ public class TextAreaView extends AbstractView {
         textAreaNoLabel.addValueChangeListener(this::onValueChange);
         add(textAreaNoLabel);
 
-        TextArea textAreaLabel = new TextArea("Label");
-        textAreaLabel.setId(LABEL);
+        TextArea textAreaLabel = new TextArea("Label (eager)");
+        textAreaLabel.setValueChangeMode(ValueChangeMode.EAGER);
+        textAreaLabel.setId(LABEL_EAGER);
         textAreaLabel.addValueChangeListener(this::onValueChange);
         add(textAreaLabel);
 

--- a/vaadin-components-testbench-test/src/main/java/com/vaadin/flow/component/textfield/testbench/test/TextFieldView.java
+++ b/vaadin-components-testbench-test/src/main/java/com/vaadin/flow/component/textfield/testbench/test/TextFieldView.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.textfield.testbench.test;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.component.common.testbench.test.AbstractView;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.lumo.Lumo;
@@ -26,7 +27,7 @@ import com.vaadin.flow.theme.lumo.Lumo;
 @Theme(Lumo.class)
 public class TextFieldView extends AbstractView {
 
-    public static final String LABEL = "text";
+    public static final String LABEL_EAGER = "text";
     public static final String NOLABEL = "notext";
     public static final String INITIAL_VALUE = "initialvalue";
     public static final String PLACEHOLDER = "placeholder";
@@ -39,8 +40,9 @@ public class TextFieldView extends AbstractView {
 
         add(textfieldNoLabel);
 
-        TextField textfieldLabel = new TextField("Label");
-        textfieldLabel.setId(LABEL);
+        TextField textfieldLabel = new TextField("Label (eager)");
+        textfieldLabel.setValueChangeMode(ValueChangeMode.EAGER);
+        textfieldLabel.setId(LABEL_EAGER);
         textfieldLabel.addValueChangeListener(this::onValueChange);
         add(textfieldLabel);
 

--- a/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/textfield/testbench/test/PasswordFieldIT.java
+++ b/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/textfield/testbench/test/PasswordFieldIT.java
@@ -24,14 +24,15 @@ import com.vaadin.flow.component.textfield.testbench.PasswordFieldElement;
 
 public class PasswordFieldIT extends AbstractIT {
 
-    private PasswordFieldElement label;
+    private PasswordFieldElement labelEager;
     private PasswordFieldElement nolabel;
     private PasswordFieldElement initialValue;
     private PasswordFieldElement placeholder;
 
     @Before
     public void find() {
-        label = $(PasswordFieldElement.class).id(PasswordFieldView.LABEL);
+        labelEager = $(PasswordFieldElement.class)
+                .id(PasswordFieldView.LABEL_EAGER);
         nolabel = $(PasswordFieldElement.class).id(PasswordFieldView.NOLABEL);
         initialValue = $(PasswordFieldElement.class)
                 .id(PasswordFieldView.INITIAL_VALUE);
@@ -41,13 +42,13 @@ public class PasswordFieldIT extends AbstractIT {
 
     @Test
     public void getSetValue() throws Exception {
-        Assert.assertEquals("", label.getValue());
+        Assert.assertEquals("", labelEager.getValue());
         Assert.assertEquals("", nolabel.getValue());
         Assert.assertEquals("Initial", initialValue.getValue());
         Assert.assertEquals("", placeholder.getValue());
 
-        label.setValue("Foo");
-        assertStringValue(label, "Foo");
+        labelEager.setValue("Foo");
+        assertStringValue(labelEager, "Foo");
 
         nolabel.setValue("Foo");
         assertStringValue(nolabel, "Foo");
@@ -60,8 +61,8 @@ public class PasswordFieldIT extends AbstractIT {
     }
 
     @Test
-    public void getLabel() throws Exception {
-        Assert.assertEquals("Label", label.getLabel());
+    public void getLabelEager() throws Exception {
+        Assert.assertEquals("Label (eager)", labelEager.getLabel());
         Assert.assertEquals("", nolabel.getLabel());
         Assert.assertEquals("Has an initial value", initialValue.getLabel());
         Assert.assertEquals("Has a placeholder", placeholder.getLabel());
@@ -69,7 +70,7 @@ public class PasswordFieldIT extends AbstractIT {
 
     @Test
     public void getPlaceholder() throws Exception {
-        Assert.assertEquals("", label.getPlaceholder());
+        Assert.assertEquals("", labelEager.getPlaceholder());
         Assert.assertEquals("", nolabel.getPlaceholder());
         Assert.assertEquals("", initialValue.getPlaceholder());
         Assert.assertEquals("Text goes here", placeholder.getPlaceholder());
@@ -77,27 +78,27 @@ public class PasswordFieldIT extends AbstractIT {
 
     @Test
     public void passwordVisible() throws Exception {
-        Assert.assertFalse(label.isPasswordVisible());
+        Assert.assertFalse(labelEager.isPasswordVisible());
         Assert.assertFalse(nolabel.isPasswordVisible());
         Assert.assertFalse(initialValue.isPasswordVisible());
         Assert.assertFalse(placeholder.isPasswordVisible());
 
-        label.setPasswordVisible(true);
+        labelEager.setPasswordVisible(true);
         nolabel.setPasswordVisible(true);
         initialValue.setPasswordVisible(true);
         placeholder.setPasswordVisible(true);
 
-        Assert.assertTrue(label.isPasswordVisible());
+        Assert.assertTrue(labelEager.isPasswordVisible());
         Assert.assertTrue(nolabel.isPasswordVisible());
         Assert.assertTrue(initialValue.isPasswordVisible());
         Assert.assertTrue(placeholder.isPasswordVisible());
 
-        label.setPasswordVisible(false);
+        labelEager.setPasswordVisible(false);
         nolabel.setPasswordVisible(false);
         initialValue.setPasswordVisible(false);
         placeholder.setPasswordVisible(false);
 
-        Assert.assertFalse(label.isPasswordVisible());
+        Assert.assertFalse(labelEager.isPasswordVisible());
         Assert.assertFalse(nolabel.isPasswordVisible());
         Assert.assertFalse(initialValue.isPasswordVisible());
         Assert.assertFalse(placeholder.isPasswordVisible());

--- a/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/textfield/testbench/test/TextAreaIT.java
+++ b/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/textfield/testbench/test/TextAreaIT.java
@@ -24,14 +24,14 @@ import com.vaadin.flow.component.textfield.testbench.TextAreaElement;
 
 public class TextAreaIT extends AbstractIT {
 
-    private TextAreaElement label;
+    private TextAreaElement labelEager;
     private TextAreaElement nolabel;
     private TextAreaElement initialValue;
     private TextAreaElement placeholder;
 
     @Before
     public void find() {
-        label = $(TextAreaElement.class).id(TextAreaView.LABEL);
+        labelEager = $(TextAreaElement.class).id(TextAreaView.LABEL_EAGER);
         nolabel = $(TextAreaElement.class).id(TextAreaView.NOLABEL);
         initialValue = $(TextAreaElement.class).id(TextAreaView.INITIAL_VALUE);
         placeholder = $(TextAreaElement.class).id(TextAreaView.PLACEHOLDER);
@@ -39,13 +39,13 @@ public class TextAreaIT extends AbstractIT {
 
     @Test
     public void getSetValue() throws Exception {
-        Assert.assertEquals("", label.getValue());
+        Assert.assertEquals("", labelEager.getValue());
         Assert.assertEquals("", nolabel.getValue());
         Assert.assertEquals("Initial", initialValue.getValue());
         Assert.assertEquals("", placeholder.getValue());
 
-        label.setValue("Foo");
-        assertStringValue(label, "Foo");
+        labelEager.setValue("Foo");
+        assertStringValue(labelEager, "Foo");
 
         nolabel.setValue("Foo");
         assertStringValue(nolabel, "Foo");
@@ -58,8 +58,8 @@ public class TextAreaIT extends AbstractIT {
     }
 
     @Test
-    public void getLabel() throws Exception {
-        Assert.assertEquals("Label", label.getLabel());
+    public void getLabelEager() throws Exception {
+        Assert.assertEquals("Label (eager)", labelEager.getLabel());
         Assert.assertEquals("", nolabel.getLabel());
         Assert.assertEquals("Has an initial value", initialValue.getLabel());
         Assert.assertEquals("Has a placeholder", placeholder.getLabel());
@@ -67,7 +67,7 @@ public class TextAreaIT extends AbstractIT {
 
     @Test
     public void getPlaceholder() throws Exception {
-        Assert.assertEquals("", label.getPlaceholder());
+        Assert.assertEquals("", labelEager.getPlaceholder());
         Assert.assertEquals("", nolabel.getPlaceholder());
         Assert.assertEquals("", initialValue.getPlaceholder());
         Assert.assertEquals("Text goes here", placeholder.getPlaceholder());

--- a/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/textfield/testbench/test/TextFieldIT.java
+++ b/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/textfield/testbench/test/TextFieldIT.java
@@ -24,14 +24,14 @@ import com.vaadin.flow.component.textfield.testbench.TextFieldElement;
 
 public class TextFieldIT extends AbstractIT {
 
-    private TextFieldElement label;
+    private TextFieldElement labelEager;
     private TextFieldElement nolabel;
     private TextFieldElement initialValue;
     private TextFieldElement placeholder;
 
     @Before
     public void find() {
-        label = $(TextFieldElement.class).id(TextFieldView.LABEL);
+        labelEager = $(TextFieldElement.class).id(TextFieldView.LABEL_EAGER);
         nolabel = $(TextFieldElement.class).id(TextFieldView.NOLABEL);
         initialValue = $(TextFieldElement.class)
                 .id(TextFieldView.INITIAL_VALUE);
@@ -40,13 +40,13 @@ public class TextFieldIT extends AbstractIT {
 
     @Test
     public void getSetValue() throws Exception {
-        Assert.assertEquals("", label.getValue());
+        Assert.assertEquals("", labelEager.getValue());
         Assert.assertEquals("", nolabel.getValue());
         Assert.assertEquals("Initial", initialValue.getValue());
         Assert.assertEquals("", placeholder.getValue());
 
-        label.setValue("Foo");
-        assertStringValue(label, "Foo");
+        labelEager.setValue("Foo");
+        assertStringValue(labelEager, "Foo");
 
         nolabel.setValue("Foo");
         assertStringValue(nolabel, "Foo");
@@ -59,8 +59,8 @@ public class TextFieldIT extends AbstractIT {
     }
 
     @Test
-    public void getLabel() throws Exception {
-        Assert.assertEquals("Label", label.getLabel());
+    public void getLabelEager() throws Exception {
+        Assert.assertEquals("Label (eager)", labelEager.getLabel());
         Assert.assertEquals("", nolabel.getLabel());
         Assert.assertEquals("Has an initial value", initialValue.getLabel());
         Assert.assertEquals("Has a placeholder", placeholder.getLabel());
@@ -68,7 +68,7 @@ public class TextFieldIT extends AbstractIT {
 
     @Test
     public void getPlaceholder() throws Exception {
-        Assert.assertEquals("", label.getPlaceholder());
+        Assert.assertEquals("", labelEager.getPlaceholder());
         Assert.assertEquals("", nolabel.getPlaceholder());
         Assert.assertEquals("", initialValue.getPlaceholder());
         Assert.assertEquals("Text goes here", placeholder.getPlaceholder());

--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/Event.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/Event.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.component.textfield.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+
+public class Event {
+
+    /**
+     * Dispatches (fires) a custom event of the given type on the element.
+     * <p>
+     * The event is created without any parameters.
+     *
+     * @param eventType
+     *            the type of custom event to dispatch
+     */
+    public static void dispatchEvent(TestBenchElement element,
+            String eventType) {
+        element.getCommandExecutor().executeScript(
+                "arguments[0].dispatchEvent(new CustomEvent(arguments[1]));",
+                element, eventType);
+    }
+
+}

--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/PasswordFieldElement.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
-import org.openqa.selenium.Keys;
-
 import com.vaadin.flow.component.common.testbench.HasLabel;
 import com.vaadin.flow.component.common.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -59,11 +57,7 @@ public class PasswordFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         HasStringValueProperty.super.setValue(string);
-        getInputElement().sendKeys(Keys.TAB);
-    }
-
-    private TestBenchElement getInputElement() {
-        return $(TestBenchElement.class).attribute("part", "value").first();
+        Event.dispatchEvent(this, "blur");
     }
 
 }

--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextAreaElement.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
-import org.openqa.selenium.Keys;
-
 import com.vaadin.flow.component.common.testbench.HasLabel;
 import com.vaadin.flow.component.common.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -33,11 +31,7 @@ public class TextAreaElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         HasStringValueProperty.super.setValue(string);
-        getInputElement().sendKeys(Keys.TAB);
-    }
-
-    private TestBenchElement getInputElement() {
-        return $(TestBenchElement.class).attribute("part", "value").first();
+        Event.dispatchEvent(this, "blur");
     }
 
 }

--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/textfield/testbench/TextFieldElement.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.textfield.testbench;
 
-import org.openqa.selenium.Keys;
-
 import com.vaadin.flow.component.common.testbench.HasLabel;
 import com.vaadin.flow.component.common.testbench.HasPlaceholder;
 import com.vaadin.testbench.HasStringValueProperty;
@@ -34,10 +32,7 @@ public class TextFieldElement extends TestBenchElement
     @Override
     public void setValue(String string) {
         HasStringValueProperty.super.setValue(string);
-        getInputElement().sendKeys(Keys.TAB);
+        Event.dispatchEvent(this, "blur");
     }
 
-    private TestBenchElement getInputElement() {
-        return $(TestBenchElement.class).attribute("part", "value").first();
-    }
 }


### PR DESCRIPTION
Fixes issues with Safari being unable to do `sendKeys` on an input element