### PR TITLE
Use fixed version of webcomponentsjs

### DIFF
--- a/vaadin-components-testbench-test/pom.xml
+++ b/vaadin-components-testbench-test/pom.xml
@@ -180,6 +180,11 @@
             <version>${ci-sauce.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+            <artifactId>webcomponentsjs</artifactId>
+            <version>1.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Incorrect range in polymer webjar resolves to webcomponentsjs 2.0.0.beta2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-components-testbench/35)
<!-- Reviewable:end -->
