### PR TITLE
Require win 8 for IE11

### DIFF
--- a/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/common/testbench/test/AbstractIT.java
+++ b/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/common/testbench/test/AbstractIT.java
@@ -22,6 +22,7 @@ import java.util.Locale;
 import org.junit.Assert;
 import org.junit.Before;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.vaadin.flow.component.common.testbench.HasLabel;
@@ -49,7 +50,12 @@ public abstract class AbstractIT extends AbstractParallelSauceLabsTest {
             for (String browserName : browsers.split(",")) {
                 Browser browser = Browser.valueOf(
                         browserName.toUpperCase(Locale.ENGLISH).trim());
-                finalList.add(browser.getDesiredCapabilities());
+                DesiredCapabilities capabilities = browser
+                        .getDesiredCapabilities();
+                if (BrowserUtil.isIE(capabilities)) {
+                    capabilities.setPlatform(Platform.WIN8_1);
+                }
+                finalList.add(capabilities);
             }
         } else {
             finalList.add(BrowserUtil.chrome());


### PR DESCRIPTION
There seems to be some issue with win10 at the moment, needs more research

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-components-testbench/56)
<!-- Reviewable:end -->
