### PR TITLE
Change upload input display style on firefox

### DIFF
--- a/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/upload/testbench/test/UploadIT.java
+++ b/vaadin-components-testbench-test/src/test/java/com/vaadin/flow/component/upload/testbench/test/UploadIT.java
@@ -52,11 +52,6 @@ public class UploadIT extends AbstractIT {
 
     @Test
     public void upload() throws Exception {
-        if (BrowserUtil.isFirefox(getDesiredCapabilities())) {
-            // Firefox has issues with interaction with hidden file input
-            // https://github.com/mozilla/geckodriver/issues/1173
-            throw new AssumptionViolatedException("Firefox doesn't allow interaction with hidden file input");
-        }
         byte[] file1Contents = "This is file 1"
                 .getBytes(StandardCharsets.UTF_8);
         byte[] file2Contents = "This is another åäö file"

--- a/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
+++ b/vaadin-components-testbench/src/main/java/com/vaadin/flow/component/upload/testbench/UploadElement.java
@@ -68,7 +68,9 @@ public class UploadElement extends TestBenchElement {
         // Element must be focusable for Edge and Firefox
         Boolean hidden = uploadElement.getPropertyBoolean("hidden");
         uploadElement.setProperty("hidden", false);
-
+        if (BrowserUtil.isFirefox(getCapabilities())) {
+            executeScript("arguments[0].style.display = \"block\";", uploadElement);
+        }
         if (!BrowserUtil.isEdge(getCapabilities())) {
             // Firefox uploads the previous file again without this
             // Edge throws "InvalidElementStateException: The element is not
@@ -77,7 +79,9 @@ public class UploadElement extends TestBenchElement {
         }
         uploadElement.sendKeys(file.getPath());
         uploadElement.setProperty("hidden", hidden);
-
+        if (BrowserUtil.isFirefox(getCapabilities())) {
+            executeScript("arguments[0].style.display = \"\";", uploadElement);
+        }
         if (maxSeconds > 0) {
             waitForUploads(maxSeconds);
         }


### PR DESCRIPTION
Force display block before sendkeys and remove diplay value afterwards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-components-testbench/65)
<!-- Reviewable:end -->
